### PR TITLE
WIP: Add a patch to mess with things

### DIFF
--- a/Source/Patches.cs
+++ b/Source/Patches.cs
@@ -1,0 +1,21 @@
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace MusicExpanded
+{
+    public class Patches
+    {
+        [HarmonyPatch(typeof(MusicManagerPlay), "ChooseNextSong")]
+        class ChooseNextSong
+        {
+            static void Postfix(MusicManagerPlay __instance, ref SongDef __result)
+            {
+                Log.Message("Patched! Saw " + __result);
+                // It's here, that we can return a different Song, and the MusicManagerPlay should just play it natively, I figure
+                // Alternatively, we could patch `StartNewSong()` with a prefix and re-write it to suit our needs
+                // Oooor crazier, `MusicUpdate()` and change everything.
+            }
+        }
+    }
+}


### PR DESCRIPTION
Just testing a patch to get an idea of how the MusicManagerPlay class works.

So far, this is the simplest thing. The method `ChooseNextSong` must return a SongDef or it'll cause a runtime error, or we patch the usage `StartNewSong()`, which is probably a better plan for messing with this functionality.