### PR TITLE
Use ModExtensions to define which events require battle tracks!

### DIFF
--- a/Patches/VanillaEvents.xml
+++ b/Patches/VanillaEvents.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationAddModExtension">
+        <xpath>/Defs/IncidentDef[
+            defName="RaidEnemy" 
+            or defName="Infestation"
+            or defName="Ambush"
+            or defName="ManhunterAmbush"
+            or defName="DeepDrillInfestation"
+            or defName="ManhunterPack"
+            or defName="AnimalInsanityMass"
+            or defName="MechCluster"
+            or defName="AnimalInsanitySingle"
+        ]</xpath>
+        <value>
+            <li Class="MusicExpanded.ModExtension.PlayCue">
+                <playBattleTrack>true</playBattleTrack>
+            </li>
+        </value>
+    </Operation>
+</Patch>

--- a/Source/ModExtension/PlayCue.cs
+++ b/Source/ModExtension/PlayCue.cs
@@ -1,0 +1,10 @@
+using Verse;
+
+namespace MusicExpanded.ModExtension
+{
+    public class PlayCue : DefModExtension
+    {
+        public bool playBattleTrack = false;
+        public Cue cue = Cue.None;
+    }
+}

--- a/Source/Patches/IncidentWorker.cs
+++ b/Source/Patches/IncidentWorker.cs
@@ -16,19 +16,21 @@ namespace MusicExpanded.Patches
         {
             static IEnumerable<MethodBase> TargetMethods()
             {
-                foreach (Type type in new List<Type> {
-                    typeof(RimWorld.IncidentWorker_RaidEnemy),
-                    typeof(RimWorld.IncidentWorker_Infestation),
-                    typeof(RimWorld.IncidentWorker_Ambush),
-                    typeof(RimWorld.IncidentWorker_AnimalInsanityMass),
-                    typeof(RimWorld.IncidentWorker_AnimalInsanitySingle),
-                    typeof(RimWorld.IncidentWorker_MechCluster)
-                })
-                {
-                    yield return AccessTools.Method(type, "TryExecuteWorker");
-                }
+                return AccessTools.AllTypes()
+                    .Where(type => type.IsSubclassOf(typeof(RimWorld.IncidentWorker)))
+                    .SelectMany(type => type.GetMethods())
+                    .Where(method => method.Name == "TryExecute");
             }
-            static void Postfix(IncidentParms parms, ref bool __result) => Utilities.PlayTrack(Utilities.BattleCue(parms.points));
+            static void Postfix(RimWorld.IncidentWorker __instance, IncidentParms parms, ref bool __result)
+            {
+                if (__result != true) return;
+                ModExtension.PlayCue playCue = __instance.def.GetModExtension<ModExtension.PlayCue>();
+                if (playCue == null) return;
+                if (playCue.playBattleTrack)
+                    Utilities.PlayTrack(Utilities.BattleCue(parms.points));
+                else
+                    Utilities.PlayTrack(playCue.cue);
+            }
 
         }
     }


### PR DESCRIPTION
Adds `MusicExpanded.ModExtension.PlayCue` to tag an `IncidentDef` with a specific Cue or battle track.
Adds a patch to vanilla threat events to play battle tracks.
Adds a patch to all IncidentWorkers to check for the mod extension, and play tracks appropriately.

Closes #26 